### PR TITLE
.spec.ts eslint error and other fixes

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "@ts-monorepo/api",
-  "version": "1.0.0",
-  "description": "API",
-  "main": "dist/main.js",
-  "type": "module",
-  "scripts": {
-    "build": "pnpm tsc --build .",
-    "start": "node dist/main.js"
-  },
-  "license": "ISC",
-  "devDependencies": {
-    "@types/koa": "^2.13.5",
-    "@types/node": "^18.7.15",
-    "typescript": "^4.8.2"
-  },
-  "dependencies": {
-    "@ts-monorepo/core": "workspace:^1.0.0",
-    "koa": "^2.13.4"
-  }
+    "name": "@ts-monorepo/api",
+    "version": "1.0.0",
+    "description": "API",
+    "main": "dist/main.js",
+    "type": "module",
+    "scripts": {
+        "build": "pnpm tsc --build .",
+        "start": "node dist/main.js"
+    },
+    "license": "ISC",
+    "devDependencies": {
+        "@types/koa": "^2.13.5",
+        "@types/node": "^18.7.15",
+        "typescript": "^4.8.2"
+    },
+    "dependencies": {
+        "@ts-monorepo/core": "workspace:^1.0.0",
+        "koa": "^2.13.4"
+    }
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../tsconfig.json",
+    "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "baseUrl": "./",
         "outDir": "dist/"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@ts-monorepo/cli",
-  "version": "1.0.0",
-  "description": "CLI application with executable creation support",
-  "type": "module",
-  "main": "./dist/main.js",
-  "files": [
-    "dist"
-  ],
-  "bin": {
-    "cli": "./dist/main.js"
-  },
-  "scripts": {
-    "build": "pnpm tsc --build .",
-    "start": "node dist/main.js",
-    "pkg": "pnpm build && pnpm dlx pkg . -o bin/app -t node16-linux-x64,node16-macos-x64,node16-win-x64"
-  },
-  "dependencies": {
-    "@ts-monorepo/core": "workspace:*"
-  },
-  "devDependencies": {
-    "typescript": "4.8.2"
-  },
-  "license": "ISC"
+    "name": "@ts-monorepo/cli",
+    "version": "1.0.0",
+    "description": "CLI application with executable creation support",
+    "type": "module",
+    "main": "./dist/main.js",
+    "files": [
+        "dist"
+    ],
+    "bin": {
+        "cli": "./dist/main.js"
+    },
+    "scripts": {
+        "build": "pnpm tsc --build .",
+        "start": "node dist/main.js",
+        "pkg": "pnpm build && pnpm dlx pkg . -o bin/app -t node16-linux-x64,node16-macos-x64,node16-win-x64"
+    },
+    "dependencies": {
+        "@ts-monorepo/core": "workspace:*"
+    },
+    "devDependencies": {
+        "typescript": "4.8.2"
+    },
+    "license": "ISC"
 }

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../tsconfig.json",
+    "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "baseUrl": "./",
         "outDir": "dist/"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@ts-monorepo/web",
-  "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
-  "devDependencies": {
-    "@types/eslint": "^8",
-    "@types/node": "^18.7.15",
-    "@types/react": "^18.0.18",
-    "eslint": "8.22.0",
-    "eslint-config-next": "12.2.5",
-    "typescript": "4.8.2"
-  },
-  "dependencies": {
-    "@ts-monorepo/core": "workspace:*",
-    "@ts-monorepo/components": "workspace:*",
-    "next": "^12.2.5",
-    "next-transpile-modules": "^9.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  }
+    "name": "@ts-monorepo/web",
+    "scripts": {
+        "dev": "next dev",
+        "build": "next build",
+        "start": "next start",
+        "lint": "next lint"
+    },
+    "devDependencies": {
+        "@types/eslint": "^8",
+        "@types/node": "^18.7.15",
+        "@types/react": "^18.0.18",
+        "eslint": "8.22.0",
+        "eslint-config-next": "12.2.5",
+        "typescript": "4.8.2"
+    },
+    "dependencies": {
+        "@ts-monorepo/core": "workspace:*",
+        "@ts-monorepo/components": "workspace:*",
+        "next": "^12.2.5",
+        "next-transpile-modules": "^9.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,27 +1,24 @@
 {
-  "compilerOptions": {
-    "baseUrl": "./",
-    "jsx": "preserve",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "incremental": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true
-  },
-  "extends": "../../tsconfig.build.json",
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "baseUrl": "./",
+        "jsx": "preserve",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "incremental": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true
+    },
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx"
+    ]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,7 +15,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.build.json",
   "include": [
     "next-env.d.ts",
     "**/*.ts",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config = {
   testMatch: defaults.testMatch,
   preset: 'ts-jest',
   testEnvironment: 'node',
+  verbose: true
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-n": "^15.0.0",
         "eslint-plugin-promise": "^6.0.0",
-        "jest": "^29.0.2",
-        "jest-config": "^29.0.2",
+        "jest": "^29.0.0",
+        "jest-config": "^29.0.0",
         "prettier": "^2.7.1",
-        "ts-jest": "^28.0.8",
+        "ts-jest": "^29.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.2"
     }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "@ts-monorepo/components",
-  "version": "1.0.0",
-  "description": "UI components library",
-  "type": "module",
-  "main": "./dist/main.js",
-  "source": "./lib/main.ts",
-  "scripts": {
-    "build": "pnpm tsc --build ."
-  },
-  "devDependencies": {
-    "@types/react": "^18.0.18",
-    "typescript": "4.8.2"
-  },
-  "license": "ISC",
-  "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  }
+    "name": "@ts-monorepo/components",
+    "version": "1.0.0",
+    "description": "UI components library",
+    "type": "module",
+    "main": "./dist/main.js",
+    "source": "./lib/main.ts",
+    "scripts": {
+        "build": "pnpm tsc --build ."
+    },
+    "devDependencies": {
+        "@types/react": "^18.0.18",
+        "typescript": "4.8.2"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    }
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../tsconfig.json",
+    "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "baseUrl": "./",
         "jsx": "preserve",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@ts-monorepo/core",
-  "version": "1.0.0",
-  "description": "Core library",
-  "type": "module",
-  "main": "./dist/main.js",
-  "scripts": {
-    "build": "pnpm tsc --build ."
-  },
-  "devDependencies": {
-    "typescript": "4.8.2"
-  },
-  "license": "ISC"
+    "name": "@ts-monorepo/core",
+    "version": "1.0.0",
+    "description": "Core library",
+    "type": "module",
+    "main": "./dist/main.js",
+    "scripts": {
+        "build": "pnpm tsc --build ."
+    },
+    "devDependencies": {
+        "typescript": "4.8.2"
+    },
+    "license": "ISC"
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,11 +1,13 @@
 {
-    "extends": "../../tsconfig.json",
+    "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "baseUrl": "./",
         "composite": true,
         "rootDir": "lib",
         "outDir": "dist/",
+        "esModuleInterop": true,
         "tsBuildInfoFile": "dist/.tsbuildinfo"
     },
-    "include": ["lib"]
+    "include": ["lib"],
+    "exclude": ["node_modules", "lib/**/*.spec.ts"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,9 +5,7 @@
         "composite": true,
         "rootDir": "lib",
         "outDir": "dist/",
-        "esModuleInterop": true,
         "tsBuildInfoFile": "dist/.tsbuildinfo"
     },
-    "include": ["lib"],
-    "exclude": ["node_modules", "lib/**/*.spec.ts"]
+    "include": ["lib"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,10 +17,10 @@ importers:
       eslint-plugin-import: ^2.25.2
       eslint-plugin-n: ^15.0.0
       eslint-plugin-promise: ^6.0.0
-      jest: ^29.0.2
-      jest-config: ^29.0.2
+      jest: ^29.0.0
+      jest-config: ^29.0.0
       prettier: ^2.7.1
-      ts-jest: ^28.0.8
+      ts-jest: ^29.0.0
       ts-node: ^10.9.1
       typescript: ^4.8.2
     devDependencies:
@@ -40,7 +40,7 @@ importers:
       jest: 29.0.2_5vwfwon4dwup6lzh6jzd72qfva
       jest-config: 29.0.2_5vwfwon4dwup6lzh6jzd72qfva
       prettier: 2.7.1
-      ts-jest: 28.0.8_3fjshojl2xcaks7h5kdeiqbdz4
+      ts-jest: 29.0.0_3fjshojl2xcaks7h5kdeiqbdz4
       ts-node: 10.9.1_r4hqq7vrw4pxsipnb7ha25ylfe
       typescript: 4.8.2
 
@@ -690,13 +690,6 @@ packages:
       - supports-color
     dev: true
 
-  /@jest/schemas/28.1.3:
-    resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.24.35
-    dev: true
-
   /@jest/schemas/29.0.0:
     resolution: {integrity: sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -754,18 +747,6 @@ packages:
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@jest/types/28.1.3:
-    resolution: {integrity: sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/schemas': 28.1.3
-      '@types/istanbul-lib-coverage': 2.0.4
-      '@types/istanbul-reports': 3.0.1
-      '@types/node': 18.7.15
-      '@types/yargs': 17.0.12
-      chalk: 4.1.2
     dev: true
 
   /@jest/types/29.0.2:
@@ -3368,18 +3349,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-util/28.1.3:
-    resolution: {integrity: sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@jest/types': 28.1.3
-      '@types/node': 18.7.15
-      chalk: 4.1.2
-      ci-info: 3.3.2
-      graceful-fs: 4.2.10
-      picomatch: 2.3.1
-    dev: true
-
   /jest-util/29.0.2:
     resolution: {integrity: sha512-ozk8ruEEEACxqpz0hN9UOgtPZS0aN+NffwQduR5dVlhN+eN47vxurtvgZkYZYMpYrsmlAEx1XabkB3BnN0GfKQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4412,16 +4381,16 @@ packages:
     engines: {node: '>=0.6'}
     dev: false
 
-  /ts-jest/28.0.8_3fjshojl2xcaks7h5kdeiqbdz4:
-    resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+  /ts-jest/29.0.0_3fjshojl2xcaks7h5kdeiqbdz4:
+    resolution: {integrity: sha512-OxUaigbv5Aon3OMLY9HBtwkGMs1upWE/URrmmVQFzzOcGlEPVuWzGmXUIkWGt/95Dj/T6MGuTrHHGL6kT6Yn8g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^28.0.0
-      babel-jest: ^28.0.0
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
       esbuild: '*'
-      jest: ^28.0.0
+      jest: ^29.0.0
       typescript: '>=4.3'
     peerDependenciesMeta:
       '@babel/core':
@@ -4436,7 +4405,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.0.2_5vwfwon4dwup6lzh6jzd72qfva
-      jest-util: 28.1.3
+      jest-util: 29.0.2
       json5: 2.2.1
       lodash.memoize: 4.1.2
       make-error: 1.3.6

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": [
+        "node_modules",
+        "**/*.spec.ts",
+        "**/*.test.ts"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,5 @@
             "@ts-monorepo/core": ["./packages/core"],
             "@ts-monorepo/components": ["./packages/components"]
         }
-    },
-    "exclude": [
-        "node_modules",
-        "**/*.spec.ts"
-    ]
+    }
 }


### PR DESCRIPTION
This PR fixes following issues:-
- ``.spec.ts`` files has eslint parsing errors
  The reason behind this error is that we have excluded ``.spec.ts`` files from ``tsconfig.json``. So, we created ``tsconfig.build.json`` that extends ``tsconfig.json`` which excludes ``.spec.ts`` files. Then we extended ``tsconfig.build.json`` file in ``apps`` and ``packages`` directories.
- Made ``jest``, ``ts-jest``, ``@jest/config`` version same because it's recommended in ``jest`` docs.
- Removed non required attributes from ``tsconfig.json`` files.
- Fixed indentation in ``package.json`` files.